### PR TITLE
Add ProNote gradebook package and CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+pronote.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # Project
-ekilpro
+
+This repository contains a small "ProNote" inspired gradebook utility. It
+provides a Python package with a `ProNote` class to manage students, subjects and
+weighted grades as well as a command line interface to interact with the data
+stored in a JSON file.
+
+## Installation
+
+The project does not require any external dependency beyond the Python standard
+library. Simply clone the repository and run the commands using your preferred
+Python interpreter (Python 3.10 or newer is recommended).
+
+## Usage
+
+The CLI lives under the `pronote` package. To see the available commands run:
+
+```bash
+python -m pronote.cli --help
+```
+
+A typical session could look like this:
+
+```bash
+python -m pronote.cli add-student "Alice"
+python -m pronote.cli add-subject "Mathematics"
+python -m pronote.cli add-grade Alice Mathematics 15 --weight 2 --comment "Exam 1"
+python -m pronote.cli report Alice
+```
+
+The commands operate on a JSON file named `pronote.json` in the current working
+folder by default. You can change the target file with the `--data` option.
+
+Refer to the `ProNote` class in `pronote/core.py` if you prefer using the API
+directly from another Python program.

--- a/pronote/__init__.py
+++ b/pronote/__init__.py
@@ -1,0 +1,5 @@
+"""ProNote package exposing the :class:`ProNote` gradebook manager."""
+
+from .core import ProNote
+
+__all__ = ["ProNote"]

--- a/pronote/__main__.py
+++ b/pronote/__main__.py
@@ -1,0 +1,8 @@
+"""Entry point that proxies to :mod:`pronote.cli`."""
+from __future__ import annotations
+
+from .cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pronote/cli.py
+++ b/pronote/cli.py
@@ -1,0 +1,150 @@
+"""Command line interface for the ProNote gradebook manager."""
+from __future__ import annotations
+
+from pathlib import Path
+import argparse
+import json
+import math
+import sys
+
+from .core import ProNote
+
+
+def load_gradebook(path: Path) -> ProNote:
+    if not path.exists():
+        return ProNote()
+    return ProNote.load(path)
+
+
+def save_gradebook(path: Path, gradebook: ProNote) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    gradebook.save(path)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Manage a small ProNote gradebook")
+    parser.add_argument(
+        "--data",
+        type=Path,
+        default=Path("pronote.json"),
+        help="Path to the JSON file storing the gradebook (default: pronote.json)",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    student_parser = subparsers.add_parser("add-student", help="Register a new student")
+    student_parser.add_argument("name", help="Name of the student to add")
+
+    remove_student_parser = subparsers.add_parser(
+        "remove-student", help="Remove a student from the gradebook"
+    )
+    remove_student_parser.add_argument("name", help="Name of the student to remove")
+
+    subject_parser = subparsers.add_parser("add-subject", help="Add a subject")
+    subject_parser.add_argument("name", help="Name of the subject to add")
+
+    remove_subject_parser = subparsers.add_parser("remove-subject", help="Remove a subject")
+    remove_subject_parser.add_argument("name", help="Name of the subject to remove")
+
+    add_grade_parser = subparsers.add_parser("add-grade", help="Attach a grade to a student")
+    add_grade_parser.add_argument("student", help="Student name")
+    add_grade_parser.add_argument("subject", help="Subject name")
+    add_grade_parser.add_argument("value", type=float, help="Grade value")
+    add_grade_parser.add_argument("--weight", type=float, default=1.0, help="Grade weight")
+    add_grade_parser.add_argument("--comment", help="Optional comment for the grade")
+
+    report_parser = subparsers.add_parser(
+        "report", help="Generate a textual report for a student"
+    )
+    report_parser.add_argument("student", help="Student name")
+
+    subparsers.add_parser("class-average", help="Display the class average")
+    subject_average_parser = subparsers.add_parser(
+        "subject-average", help="Display the average for a subject"
+    )
+    subject_average_parser.add_argument("subject", help="Subject name")
+
+    export_parser = subparsers.add_parser("export", help="Dump the gradebook as JSON")
+    export_parser.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="Indentation level for the exported JSON (default: 2)",
+    )
+
+    subparsers.add_parser("list-students", help="List all registered students")
+    subparsers.add_parser("list-subjects", help="List all available subjects")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    data_path: Path = args.data
+    gradebook = load_gradebook(data_path)
+
+    try:
+        if args.command == "add-student":
+            gradebook.add_student(args.name)
+            save_gradebook(data_path, gradebook)
+            print(f"Student '{args.name}' added")
+        elif args.command == "remove-student":
+            gradebook.remove_student(args.name)
+            save_gradebook(data_path, gradebook)
+            print(f"Student '{args.name}' removed")
+        elif args.command == "add-subject":
+            gradebook.add_subject(args.name)
+            save_gradebook(data_path, gradebook)
+            print(f"Subject '{args.name}' added")
+        elif args.command == "remove-subject":
+            gradebook.remove_subject(args.name)
+            save_gradebook(data_path, gradebook)
+            print(f"Subject '{args.name}' removed")
+        elif args.command == "add-grade":
+            gradebook.add_grade(
+                args.student,
+                args.subject,
+                args.value,
+                weight=args.weight,
+                comment=args.comment,
+            )
+            save_gradebook(data_path, gradebook)
+            print(
+                f"Grade {args.value} for subject '{args.subject}' "
+                f"added to student '{args.student}'"
+            )
+        elif args.command == "report":
+            print(gradebook.student_report(args.student))
+        elif args.command == "class-average":
+            average = gradebook.class_average()
+            if math.isnan(average):
+                print("No grades available yet")
+            else:
+                print(f"Class average: {average:.2f}")
+        elif args.command == "subject-average":
+            average = gradebook.subject_average(args.subject)
+            if math.isnan(average):
+                print("No grades available yet")
+            else:
+                print(f"Average for {args.subject}: {average:.2f}")
+        elif args.command == "export":
+            json.dump(gradebook.to_dict(), sys.stdout, indent=args.indent, ensure_ascii=False)
+            print()
+        elif args.command == "list-students":
+            for student in sorted(gradebook._students):
+                print(student)
+        elif args.command == "list-subjects":
+            for subject in sorted(gradebook._subjects):
+                print(subject)
+        else:
+            parser.error("Unknown command")
+            return 2
+    except (ValueError, KeyError) as exc:
+        parser.error(str(exc))
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pronote/core.py
+++ b/pronote/core.py
@@ -1,0 +1,250 @@
+"""Core gradebook logic for the ProNote mini application."""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, MutableMapping, Optional
+import json
+import math
+
+
+@dataclass
+class Grade:
+    """Represents a single graded item."""
+
+    value: float
+    weight: float = 1.0
+    comment: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, float | str]:
+        """Return a JSON serialisable representation of the grade."""
+        data = asdict(self)
+        if data["comment"] is None:
+            data.pop("comment")
+        return data
+
+    @classmethod
+    def from_dict(cls, payload: MutableMapping[str, object]) -> "Grade":
+        """Re-create a :class:`Grade` from a dictionary."""
+        return cls(
+            value=float(payload["value"]),
+            weight=float(payload.get("weight", 1.0)),
+            comment=payload.get("comment"),
+        )
+
+
+class ProNote:
+    """A small gradebook manager inspired by the French "ProNote" software."""
+
+    def __init__(self) -> None:
+        self._subjects: set[str] = set()
+        self._students: Dict[str, Dict[str, List[Grade]]] = {}
+
+    # ------------------------------------------------------------------
+    # Student & subject management
+    # ------------------------------------------------------------------
+    def add_student(self, name: str) -> None:
+        """Register a new student in the gradebook."""
+        name = name.strip()
+        if not name:
+            raise ValueError("Student name cannot be empty")
+        if name in self._students:
+            raise ValueError(f"Student '{name}' already exists")
+        self._students[name] = {subject: [] for subject in self._subjects}
+
+    def remove_student(self, name: str) -> None:
+        """Remove a student from the gradebook."""
+        if name not in self._students:
+            raise KeyError(f"Unknown student: {name}")
+        del self._students[name]
+
+    def add_subject(self, name: str) -> None:
+        """Add a new subject to the gradebook."""
+        name = name.strip()
+        if not name:
+            raise ValueError("Subject name cannot be empty")
+        if name in self._subjects:
+            raise ValueError(f"Subject '{name}' already exists")
+        self._subjects.add(name)
+        for student in self._students.values():
+            student[name] = []
+
+    def remove_subject(self, name: str) -> None:
+        """Remove a subject and all associated grades."""
+        if name not in self._subjects:
+            raise KeyError(f"Unknown subject: {name}")
+        self._subjects.remove(name)
+        for student in self._students.values():
+            student.pop(name, None)
+
+    # ------------------------------------------------------------------
+    # Grade management
+    # ------------------------------------------------------------------
+    def add_grade(
+        self,
+        student: str,
+        subject: str,
+        value: float,
+        *,
+        weight: float = 1.0,
+        comment: Optional[str] = None,
+    ) -> None:
+        """Attach a grade to a student and subject."""
+        record = self._get_subject_grades(student, subject)
+        record.append(Grade(value=float(value), weight=float(weight), comment=comment))
+
+    def clear_grades(self, student: str, subject: Optional[str] = None) -> None:
+        """Remove all grades for a student."""
+        if student not in self._students:
+            raise KeyError(f"Unknown student: {student}")
+        if subject is None:
+            for grades in self._students[student].values():
+                grades.clear()
+        else:
+            self._get_subject_grades(student, subject).clear()
+
+    # ------------------------------------------------------------------
+    # Average computations
+    # ------------------------------------------------------------------
+    def student_average(self, student: str, subject: Optional[str] = None) -> float:
+        """Compute the weighted average for a student."""
+        if student not in self._students:
+            raise KeyError(f"Unknown student: {student}")
+
+        if subject is not None:
+            grades = self._get_subject_grades(student, subject)
+            return self._average(grades)
+
+        all_grades: List[Grade] = []
+        for grades in self._students[student].values():
+            all_grades.extend(grades)
+        return self._average(all_grades)
+
+    def subject_average(self, subject: str) -> float:
+        """Average grade for a subject across all students."""
+        if subject not in self._subjects:
+            raise KeyError(f"Unknown subject: {subject}")
+        all_grades: List[Grade] = []
+        for student in self._students.values():
+            all_grades.extend(student.get(subject, []))
+        return self._average(all_grades)
+
+    def class_average(self) -> float:
+        """Overall average for the classroom."""
+        all_grades: List[Grade] = []
+        for student in self._students.values():
+            for grades in student.values():
+                all_grades.extend(grades)
+        return self._average(all_grades)
+
+    # ------------------------------------------------------------------
+    # Reporting utilities
+    # ------------------------------------------------------------------
+    def student_report(self, student: str) -> str:
+        """Return a textual report for a student."""
+        if student not in self._students:
+            raise KeyError(f"Unknown student: {student}")
+        title = f"Report for {student}"
+        lines = [title, "=" * len(title)]
+        for subject in sorted(self._subjects):
+            grades = self._students[student].get(subject, [])
+            lines.append("")
+            lines.append(subject)
+            lines.append("-" * len(subject))
+            if not grades:
+                lines.append("No grades yet")
+                continue
+            for grade in grades:
+                line = f"- {grade.value:.2f} (weight {grade.weight:g})"
+                if grade.comment:
+                    line += f" – {grade.comment}"
+                lines.append(line)
+            avg = self._average(grades)
+            if not math.isnan(avg):
+                lines.append(f"Subject average: {avg:.2f}")
+        overall = self.student_average(student)
+        if not math.isnan(overall):
+            lines.append("")
+            lines.append(f"Overall average: {overall:.2f}")
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    # ------------------------------------------------------------------
+    def to_dict(self) -> Dict[str, object]:
+        """Serialize the gradebook to a plain dictionary."""
+        return {
+            "subjects": sorted(self._subjects),
+            "students": {
+                student: {
+                    subject: [grade.to_dict() for grade in grades]
+                    for subject, grades in subjects.items()
+                }
+                for student, subjects in self._students.items()
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, payload: MutableMapping[str, object]) -> "ProNote":
+        """Restore a :class:`ProNote` instance from serialized data."""
+        instance = cls()
+        subjects = payload.get("subjects", [])
+        for subject in subjects:
+            instance._subjects.add(str(subject))
+        students = payload.get("students", {})
+        for student_name, subjects_payload in students.items():
+            student_name = str(student_name)
+            instance._students[student_name] = {}
+            for subject in instance._subjects:
+                instance._students[student_name][subject] = []
+            for subject_name, grades_payload in subjects_payload.items():
+                subject_name = str(subject_name)
+                if subject_name not in instance._subjects:
+                    instance._subjects.add(subject_name)
+                    for record in instance._students.values():
+                        record.setdefault(subject_name, [])
+                grade_list = [
+                    Grade.from_dict(grade_payload)  # type: ignore[arg-type]
+                    for grade_payload in grades_payload
+                ]
+                instance._students[student_name][subject_name] = grade_list
+        for student_name in list(instance._students):
+            for subject in instance._subjects:
+                instance._students[student_name].setdefault(subject, [])
+        return instance
+
+    def save(self, path: str | Path) -> None:
+        """Persist the gradebook to a JSON file."""
+        data = self.to_dict()
+        Path(path).write_text(json.dumps(data, indent=2, ensure_ascii=False))
+
+    @classmethod
+    def load(cls, path: str | Path) -> "ProNote":
+        """Load gradebook information from a JSON file."""
+        content = Path(path).read_text()
+        data = json.loads(content)
+        return cls.from_dict(data)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _get_subject_grades(self, student: str, subject: str) -> List[Grade]:
+        if student not in self._students:
+            raise KeyError(f"Unknown student: {student}")
+        if subject not in self._subjects:
+            raise KeyError(f"Unknown subject: {subject}")
+        subjects = self._students[student]
+        if subject not in subjects:
+            subjects[subject] = []
+        return subjects[subject]
+
+    @staticmethod
+    def _average(grades: Iterable[Grade]) -> float:
+        total = 0.0
+        total_weight = 0.0
+        for grade in grades:
+            total += grade.value * grade.weight
+            total_weight += grade.weight
+        if total_weight == 0:
+            return float("nan")
+        return total / total_weight


### PR DESCRIPTION
## Summary
- implement a ProNote-inspired gradebook core with weighted grades, averages, reports, and JSON persistence helpers
- add a command-line interface (and `python -m pronote` entry point) to manage students, subjects, grades, and exports
- document usage in the README and ignore generated caches and data files

## Testing
- python -m pronote.cli --help
- python -m pronote.cli --data sample.json add-student Alice
- python -m pronote.cli --data sample.json add-subject Mathematics
- python -m pronote.cli --data sample.json add-grade Alice Mathematics 17 --weight 2 --comment "Quiz"
- python -m pronote.cli --data sample.json report Alice
- python -m pronote --help

------
https://chatgpt.com/codex/tasks/task_e_68dc25c4a92c8329a320ff53972476ae